### PR TITLE
chore: refactor update and copy list of points on load

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ and `offset` is the amount of points to skip (for pagination).
 
 Returns the zoom on which the cluster expands into several children (useful for "click to zoom" feature) given the cluster's `cluster_id`.
 
-#### `updatePointProperties(point)`
+#### `updatePointProperties(id, properties)`
 
-Updates the point in the cluster with the same id (according to `getId`) to the provided point. If the given point has no corresponding point in the cluster with the same id or the location of the point (`point.geometry.coordinates`) is not the same, this method will throw an error.
+Updates the point in the cluster with the same `id` (according to `getId`), with the given `properties`. If the given `id` is not present in the cluster, this method will throw an error. The location of the point (`point.geometry.coordinates`) can not be updated through this method.
 
 ## Options
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 
 import RBush from 'rbush';
+import _ from 'lodash';
 
 class MyRBush extends RBush {
     // eslint-disable-next-line class-methods-use-this
@@ -60,14 +61,14 @@ export default class Supercluster {
         const timerId = `prepare ${  points.length  } points`;
         if (log) console.time(timerId);
 
-        this.points = points;
+        this.points = structuredClone(points);
 
         // generate a cluster object for each point and index input points into a R-tree
         const currentClusterData = [];
         const currentIndexData = [];
 
-        for (let i = 0; i < points.length; i++) {
-            const p = points[i];
+        for (let i = 0; i < this.points.length; i++) {
+            const p = this.points[i];
             if (!p.geometry) continue;
 
             const [lng, lat] = p.geometry.coordinates;
@@ -213,13 +214,13 @@ export default class Supercluster {
         return expansionZoom;
     }
 
-    updatePointProperties(point) {
-        const idx = this._linearSearchInPoints(point);
-        if (!idx) throw new Error('No point with the same id could be found in the current cluster.');
-        const [oldLng, oldLat] = this.points[idx].geometry.coordinates;
-        const [newLng, newLat] = point.geometry.coordinates;
-        if (oldLng !== newLng || oldLat !== newLat) throw new Error('The location of the updated point should be the same when using updatePointProperties().');
-        this.points[idx] = point;
+    updatePointProperties(id, properties) {
+        const idx = this._linearSearchInPoints(id);
+        if (!idx) throw new Error('No point with the given id could be found.');
+
+        const clonedProperties = structuredClone(properties);
+        delete clonedProperties.geometry?.coordinates;
+        this.points[idx] = _.merge(this.points[idx], clonedProperties);
     }
 
     _appendLeaves(result, clusterId, limit, offset, skipped) {
@@ -422,9 +423,8 @@ export default class Supercluster {
         return result;
     }
 
-    _linearSearchInPoints(point) {
-        const pointId = this.getId(point);
-        const index = this.points.findIndex(p => this.getId(p) === pointId);
+    _linearSearchInPoints(id) {
+        const index = this.points.findIndex(p => this.getId(p) === id);
         return index !== -1 ? index : null;
     }
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 
 import RBush from 'rbush';
-import _ from 'lodash';
+import {merge as lodashMerge} from 'lodash-es';
 
 class MyRBush extends RBush {
     // eslint-disable-next-line class-methods-use-this
@@ -220,7 +220,7 @@ export default class Supercluster {
 
         const clonedProperties = structuredClone(properties);
         delete clonedProperties.geometry?.coordinates;
-        this.points[idx] = _.merge(this.points[idx], clonedProperties);
+        lodashMerge(this.points[idx], clonedProperties);
     }
 
     _appendLeaves(result, clusterId, limit, offset, skipped) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.3",
       "license": "ISC",
       "dependencies": {
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "rbush": "^4.0.1"
       },
       "devDependencies": {
@@ -1352,10 +1352,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
+    "node_modules/lodash-es": {
       "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "mutable-supercluster",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mutable-supercluster",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "ISC",
       "dependencies": {
+        "lodash": "^4.17.21",
         "rbush": "^4.0.1"
       },
       "devDependencies": {
@@ -1350,6 +1351,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "author": "Sander Verwimp",
   "license": "ISC",
   "dependencies": {
-    "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
     "rbush": "^4.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mutable-supercluster",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A library for fast and mutable geospatial point clustering.",
   "main": "dist/mutable-supercluster.js",
   "type": "module",
@@ -32,6 +32,7 @@
   "author": "Sander Verwimp",
   "license": "ISC",
   "dependencies": {
+    "lodash": "^4.17.21",
     "rbush": "^4.0.1"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -19,27 +19,27 @@ const placesTileMin5 = JSON.parse(readFileSync(new URL('./fixtures/places-z0-0-0
 const sortedTileMin5Features = placesTileMin5.features.sort(compareFn);
 
 test('generates clusters properly', () => {
-    const index = new Supercluster({getId}).load(structuredClone(places.features));
+    const index = new Supercluster({getId}).load(places.features);
     const tile = index.getTile(0, 0, 0);
     tile.features.sort(compareFn);
     assert.deepEqual(tile.features, sortedTileFeatures);
 });
 
 test('supports minPoints option', () => {
-    const index = new Supercluster({minPoints: 5, getId}).load(structuredClone(places.features));
+    const index = new Supercluster({minPoints: 5, getId}).load(places.features);
     const tile = index.getTile(0, 0, 0);
     tile.features.sort(compareFn);
     assert.deepEqual(tile.features, sortedTileMin5Features);
 });
 
 test('returns children of a cluster', () => {
-    const index = new Supercluster({getId}).load(structuredClone(places.features));
+    const index = new Supercluster({getId}).load(places.features);
     const childCounts = index.getChildren(164).map(p => p.properties.point_count || 1);
     assert.deepEqual(childCounts, [1, 7, 2, 6]);
 });
 
 test('returns leaves of a cluster', () => {
-    const index = new Supercluster({getId}).load(structuredClone(places.features));
+    const index = new Supercluster({getId}).load(places.features);
     const leafNames = index.getLeaves(164, 10, 5).map(p => p.properties.name);
     assert.deepEqual(leafNames, [
         'I. de Cozumel',
@@ -56,13 +56,13 @@ test('returns leaves of a cluster', () => {
 });
 
 test('generates unique ids with generateId option', () => {
-    const index = new Supercluster({generateId: true, getId}).load(structuredClone(places.features));
+    const index = new Supercluster({generateId: true, getId}).load(places.features);
     const ids = index.getTile(0, 0, 0).features.filter(f => !f.tags.cluster).map(f => f.id);
     assert.deepEqual(ids, [62,  24, 22,  12, 28, 20, 125, 119, 30, 118, 81, 21, 81, 118]);
 });
 
 test('getLeaves handles null-property features', () => {
-    const index = new Supercluster({getId}).load(structuredClone(places.features).concat([{
+    const index = new Supercluster({getId}).load(places.features.concat([{
         type: 'Feature',
         properties: null,
         geometry: {
@@ -75,7 +75,7 @@ test('getLeaves handles null-property features', () => {
 });
 
 test('returns cluster expansion zoom', () => {
-    const index = new Supercluster({getId}).load(structuredClone(places.features));
+    const index = new Supercluster({getId}).load(places.features);
     assert.deepEqual(index.getClusterExpansionZoom(164), 1);
     assert.deepEqual(index.getClusterExpansionZoom(196), 1);
     assert.deepEqual(index.getClusterExpansionZoom(581), 2);
@@ -89,7 +89,7 @@ test('returns cluster expansion zoom for maxZoom', () => {
         extent: 256,
         maxZoom: 4,
         getId
-    }).load(structuredClone(places.features));
+    }).load(places.features);
 
     assert.deepEqual(index.getClusterExpansionZoom(2504), 5);
 });
@@ -100,7 +100,7 @@ test('aggregates cluster properties with reduce', () => {
         reduce: (a, b) => { a.sum += b.sum; },
         radius: 100,
         getId
-    }).load(structuredClone(places.features));
+    }).load(places.features);
 
     assert.deepEqual(index.getTile(1, 0, 0).features.map(f => f.tags.sum).filter(Boolean),
         [8, 19, 12, 23, 146, 34, 8, 29, 84, 63, 35, 80]);
@@ -150,7 +150,7 @@ test('returns clusters when query crosses international dateline', () => {
 });
 
 test('does not crash on weird bbox values', () => {
-    const index = new Supercluster({getId}).load(structuredClone(places.features));
+    const index = new Supercluster({getId}).load(places.features);
     assert.equal(index.getClusters([129.426390, -103.720017, -445.930843, 114.518236], 1).length, 26);
     assert.equal(index.getClusters([112.207836, -84.578666, -463.149397, 120.169159], 1).length, 27);
     assert.equal(index.getClusters([129.886277, -82.332680, -445.470956, 120.390930], 1).length, 26);
@@ -161,7 +161,7 @@ test('does not crash on weird bbox values', () => {
 });
 
 test('does not crash on non-integer zoom values', () => {
-    const index = new Supercluster({getId}).load(structuredClone(places.features));
+    const index = new Supercluster({getId}).load(places.features);
     assert.ok(index.getClusters([179, -10, -177, 10], 1.25));
 });
 
@@ -195,7 +195,7 @@ test('does not throw on zero items', () => {
 });
 
 test('update properties succeeds', () => {
-    const index = new Supercluster({getId}).load(structuredClone(places.features));
+    const index = new Supercluster({getId}).load(places.features);
     const leafNames = index.getLeaves(164, 3, 5).map(p => p.properties.name);
     assert.deepEqual(leafNames, [
         'I. de Cozumel',
@@ -203,9 +203,7 @@ test('update properties succeeds', () => {
         'Grand Cayman',
     ]);
     // Update name of point 160, currently named I. de Cozumel.
-    const point = structuredClone(places.features[160]);
-    point.properties.name = 'New York';
-    index.updatePointProperties(point);
+    index.updatePointProperties(160, {properties: {name: 'New York'}});
     const newLeafNames = index.getLeaves(164, 3, 5).map(p => p.properties.name);
     assert.deepEqual(newLeafNames, [
         'New York',
@@ -215,11 +213,9 @@ test('update properties succeeds', () => {
 });
 
 test('update properties with different location fails', () => {
-    const index = new Supercluster({getId}).load(structuredClone(places.features));
+    const index = new Supercluster({getId}).load(places.features);
     // Change location of point 160 and try to update.
-    const point = structuredClone(places.features[160]);
-    point.geometry.coordinates = [0, 0];
-    assert.throws(() => index.updatePointProperties(point));
+    index.updatePointProperties(160, {geometry: {coordinates: [0, 0]}});
     // Result should not have changed.
     const leafNames = index.getLeaves(164, 3, 5).map(p => p.properties.name);
     assert.deepEqual(leafNames, [


### PR DESCRIPTION
This PR refactors the update method to not take in the entire updated point but just the id and object of properties to update.